### PR TITLE
Add 'time' module to fix NameError

### DIFF
--- a/carelink_client.py
+++ b/carelink_client.py
@@ -29,6 +29,7 @@ import json
 import requests
 from datetime import datetime, timedelta
 from urllib.parse import urlparse, parse_qsl
+import time
 
 # Version string
 VERSION = "0.6"


### PR DESCRIPTION
In this commit, the 'time' module was added at the beginning of the script to resolve a NameError that occurred in the 'CareLinkClient' class. The NameError was raised because the code attempted to access 'time.time()' in the '__getLast24Hours' method without importing the 'time' module first. By adding the 'import time' statement, the 'time' module is now available for use, and the error is resolved. The script can now properly access the 'time' module to perform the required time-related operations without any issues.