### PR TITLE
Update README with initialization example and missing parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cd carelink-python-client
 
     import carelink_client
     
-    client = carelink_client.CareLinkClient("carelink_username", "carelink_password", "carelink_country_code")
+    client = carelink_client.CareLinkClient("carelink_username", "carelink_password", "carelink_country_code", "patient_id")
     if client.login():
         recentData = client.getRecentData()
 


### PR DESCRIPTION
This commit updates the README to include a corrected example of initializing the 'carelink_client' module. The previous example lacked one required parameter for the 'CareLinkClient' class, which resulted in an error. The corrected example now includes the 'carelinkPatient' parameter, allowing the 'CareLinkClient' object to be properly initialized with all required values. The example now looks like this:
```
### Get data of last 24 hours using Python

import carelink_client

client = carelink_client.CareLinkClient("carelink_username", "carelink_password", "carelink_country_code", "patient_id")
if client.login():
    recentData = client.getRecentData()
```
With this change, users can now follow the updated example to initialize the 'CareLinkClient' class correctly and obtain data for the last 24 hours without encountering any issues.